### PR TITLE
Remove @internal from FormAssertion

### DIFF
--- a/src/Symfony/Helper/FormAssertion.php
+++ b/src/Symfony/Helper/FormAssertion.php
@@ -19,6 +19,11 @@ use function PHPUnit\Framework\atLeastOnce;
 
 class FormAssertion
 {
+    /**
+     * @internal Instance should not be made directly, use AbstractControllerTestCase::expectCreateForm
+     *
+     * @see AbstractControllerTestCase::expectCreateForm
+     */
     public function __construct(public readonly FormInterface&MockObject $form, private readonly TestCase $testCase)
     {
     }

--- a/src/Symfony/Helper/FormAssertion.php
+++ b/src/Symfony/Helper/FormAssertion.php
@@ -17,9 +17,6 @@ use Symfony\Component\HttpFoundation\Request;
 
 use function PHPUnit\Framework\atLeastOnce;
 
-/**
- * @internal
- */
 class FormAssertion
 {
     public function __construct(public readonly FormInterface&MockObject $form, private readonly TestCase $testCase)


### PR DESCRIPTION
This class is used by method chaining the expect methods on AbstractControllerTestCase. As such this class is allowed to be called from outside the package, and also has to follow the BC rules.