### PR TITLE
Add violation builder assertion class

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,47 @@ class MyControllerTest extends AbstractControllerTestCase
 - `expectForward`
 - `expectRender`
 
+### Symfony ConstraintValidator tests
+
+```php
+use DR\PHPUnitExtensions\Symfony\AbstractConstraintValidatorTestCase;
+
+class MyConstraintValidatorTest extends AbstractConstraintValidatorTestCase 
+{    
+    public function testValidate(): void
+    {
+        $this->expectBuildViolation($constraint->message, ['parameter' => 123])
+            ->expectSetCode(789)
+            ->expectAtPath('path')
+            ->expectAddViolation();
+
+        $this->validator->validate(123, $this->constraint);
+    }
+    
+    protected function getValidator(): ConstraintValidator
+    {
+        return new MyConstraintValidator();
+    }
+
+    protected function getConstraint(): Constraint
+    {
+        return new MyConstraint();
+    }
+}
+```
+
+**Methods**
+- `expectSetInvalidValue`
+- `expectSetPlural`
+- `expectSetCode`
+- `expectSetCause`
+- `expectSetTranslationDomain`
+- `expectSetParameters`
+- `expectSetParameter`
+- `expectSetParameterWithConsecutive`
+- `expectAtPath`
+- `expectAddViolation`
+
 ## About us
 
 At 123inkt (Part of Digital Revolution B.V.), every day more than 50 development professionals are working on improving our internal ERP 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ class MyControllerTest extends AbstractControllerTestCase
 
 ### Symfony ConstraintValidator tests
 
+TestCase for testing Symfony ConstraintValidators.
+
 ```php
 use DR\PHPUnitExtensions\Symfony\AbstractConstraintValidatorTestCase;
 
@@ -83,6 +85,11 @@ class MyConstraintValidatorTest extends AbstractConstraintValidatorTestCase
 ```
 
 **Methods**
+- `assertHandlesIncorrectConstraintType`
+- `expectNoViolations`
+- `expectBuildViolation(): ConstraintViolationBuilderAssertion`
+
+**ConstraintViolationBuilderAssertion**
 - `expectSetInvalidValue`
 - `expectSetPlural`
 - `expectSetCode`

--- a/src/Symfony/AbstractConstraintValidatorTestCase.php
+++ b/src/Symfony/AbstractConstraintValidatorTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DR\PHPUnitExtensions\Symfony;
 
+use DR\PHPUnitExtensions\Symfony\Helper\ConstraintViolationBuilderAssertion;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -102,6 +103,8 @@ abstract class AbstractConstraintValidatorTestCase extends TestCase
      * e.g. $this->context->buildViolation($constraint->message)->atPath('price')->setInvalidValue($price)->addViolation();
      *
      * @param array<int|string, mixed> $parameters
+     *
+     * @deprecated use ::expectBuildViolation
      */
     protected function expectViolationViaBuilder(
         string $message,
@@ -117,5 +120,32 @@ abstract class AbstractConstraintValidatorTestCase extends TestCase
             $this->violationBuilder->expects(static::once())->method('setInvalidValue')->with($invalidValue)->willReturnSelf();
         }
         $this->violationBuilder->expects(static::once())->method('addViolation');
+    }
+
+    /**
+     * Expect a violation to be created using the violation builder.
+     * Example:
+     * <code>
+     *     $this->context
+     *          ->buildViolation($constraint->message)
+     *          ->atPath('price')
+     *          ->setInvalidValue(5.0)
+     *          ->addViolation();
+     * </code>
+     * Usage:
+     * <code>
+     *     $this->expectBuildViolation('message')
+     *          ->expectAtPath('price')
+     *          ->expectSetInvalidValue(5.0)
+     *          ->expectAddViolation();
+     * </code>
+     *
+     * @param array<int|string, mixed> $parameters
+     */
+    protected function expectBuildViolation(string $message, array $parameters = []): ConstraintViolationBuilderAssertion
+    {
+        $this->executionContext->expects(static::once())->method('buildViolation')->with($message, $parameters)->willReturn($this->violationBuilder);
+
+        return new ConstraintViolationBuilderAssertion($this->violationBuilder);
     }
 }

--- a/src/Symfony/Helper/ConstraintViolationBuilderAssertion.php
+++ b/src/Symfony/Helper/ConstraintViolationBuilderAssertion.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace DR\PHPUnitExtensions\Symfony\Helper;
 

--- a/src/Symfony/Helper/ConstraintViolationBuilderAssertion.php
+++ b/src/Symfony/Helper/ConstraintViolationBuilderAssertion.php
@@ -75,11 +75,11 @@ class ConstraintViolationBuilderAssertion
     }
 
     /**
-     * @param array<int, mixed> $parameters
+     * @param array<int, mixed> $arguments
      */
-    public function expectSetParameterWithConsecutive(array ...$parameters): self
+    public function expectSetParameterWithConsecutive(array ...$arguments): self
     {
-        $this->violationBuilder->expects(atLeastOnce())->method('setParameter')->with(...consecutive(...$parameters))->willReturnSelf();
+        $this->violationBuilder->expects(atLeastOnce())->method('setParameter')->with(...consecutive(...$arguments))->willReturnSelf();
 
         return $this;
     }

--- a/src/Symfony/Helper/ConstraintViolationBuilderAssertion.php
+++ b/src/Symfony/Helper/ConstraintViolationBuilderAssertion.php
@@ -8,6 +8,9 @@ use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 use function DR\PHPUnitExtensions\Mock\consecutive;
 use function PHPUnit\Framework\atLeastOnce;
 
+/**
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ */
 class ConstraintViolationBuilderAssertion
 {
     /**

--- a/src/Symfony/Helper/ConstraintViolationBuilderAssertion.php
+++ b/src/Symfony/Helper/ConstraintViolationBuilderAssertion.php
@@ -32,6 +32,13 @@ class ConstraintViolationBuilderAssertion
         return $this;
     }
 
+    public function expectSetCode(string $code): self
+    {
+        $this->violationBuilder->expects(atLeastOnce())->method('setCode')->with($code)->willReturnSelf();
+
+        return $this;
+    }
+
     public function expectSetCause(mixed $cause): self
     {
         $this->violationBuilder->expects(atLeastOnce())->method('setCause')->with($cause)->willReturnSelf();
@@ -64,9 +71,9 @@ class ConstraintViolationBuilderAssertion
     }
 
     /**
-     * @param array<int, array<string, mixed>> $parameters
+     * @param array<int, mixed> $parameters
      */
-    public function expectSetParameterWithConsecutive(array $parameters): self
+    public function expectSetParameterWithConsecutive(array ...$parameters): self
     {
         $this->violationBuilder->expects(atLeastOnce())->method('setParameter')->with(...consecutive(...$parameters))->willReturnSelf();
 

--- a/src/Symfony/Helper/ConstraintViolationBuilderAssertion.php
+++ b/src/Symfony/Helper/ConstraintViolationBuilderAssertion.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace DR\PHPUnitExtensions\Symfony\Helper;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+use function DR\PHPUnitExtensions\Mock\consecutive;
+use function PHPUnit\Framework\atLeastOnce;
+
+class ConstraintViolationBuilderAssertion
+{
+    /**
+     * @internal Instance should not be made directly, use AbstractConstraintValidatorTestCase::expectBuildViolation
+     * @see      AbstractConstraintValidatorTestCase::expectBuildViolation
+     */
+    public function __construct(public readonly ConstraintViolationBuilderInterface&MockObject $violationBuilder)
+    {
+    }
+
+    public function expectSetInvalidValue(mixed $value): self
+    {
+        $this->violationBuilder->expects(atLeastOnce())->method('setInvalidValue')->with($value)->willReturnSelf();
+
+        return $this;
+    }
+
+    public function expectSetPlural(int $number): self
+    {
+        $this->violationBuilder->expects(atLeastOnce())->method('setPlural')->with($number)->willReturnSelf();
+
+        return $this;
+    }
+
+    public function expectSetCause(mixed $cause): self
+    {
+        $this->violationBuilder->expects(atLeastOnce())->method('setCause')->with($cause)->willReturnSelf();
+
+        return $this;
+    }
+
+    public function expectSetTranslationDomain(string $translationDomain): self
+    {
+        $this->violationBuilder->expects(atLeastOnce())->method('setTranslationDomain')->with($translationDomain)->willReturnSelf();
+
+        return $this;
+    }
+
+    /**
+     * @param array<int|string, mixed> $parameters
+     */
+    public function expectSetParameters(array $parameters): self
+    {
+        $this->violationBuilder->expects(atLeastOnce())->method('setParameters')->with($parameters)->willReturnSelf();
+
+        return $this;
+    }
+
+    public function expectSetParameter(string $key, mixed $value): self
+    {
+        $this->violationBuilder->expects(atLeastOnce())->method('setParameter')->with($key, $value)->willReturnSelf();
+
+        return $this;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $parameters
+     */
+    public function expectSetParameterWithConsecutive(array $parameters): self
+    {
+        $this->violationBuilder->expects(atLeastOnce())->method('setParameter')->with(...consecutive(...$parameters))->willReturnSelf();
+
+        return $this;
+    }
+
+    public function expectAtPath(string $path): self
+    {
+        $this->violationBuilder->expects(atLeastOnce())->method('atPath')->with($path)->willReturnSelf();
+
+        return $this;
+    }
+
+    public function expectAddViolation(): self
+    {
+        $this->violationBuilder->expects(atLeastOnce())->method('addViolation')->willReturnSelf();
+
+        return $this;
+    }
+}

--- a/tests/Integration/Symfony/ConstraintValidator/ConstraintValidatorTest.php
+++ b/tests/Integration/Symfony/ConstraintValidator/ConstraintValidatorTest.php
@@ -14,6 +14,7 @@ use Symfony\Component\Validator\ConstraintValidator;
 /**
  * @extends AbstractConstraintValidatorTestCase<TestConstraintValidator, TestConstraint>
  * @covers \DR\PHPUnitExtensions\Symfony\AbstractConstraintValidatorTestCase
+ * @covers \DR\PHPUnitExtensions\Symfony\Helper\ConstraintViolationBuilderAssertion
  */
 class ConstraintValidatorTest extends AbstractConstraintValidatorTestCase
 {
@@ -53,15 +54,38 @@ class ConstraintValidatorTest extends AbstractConstraintValidatorTestCase
         $this->validator->validate(TestConstraintValidator::VALUE_ADD_VIOLATION, $this->constraint);
     }
 
-    public function testBuildViolation(): void
+    public function testBuildViolationViaBuilder(): void
     {
         $this->expectViolationViaBuilder($this->constraint->message);
         $this->validator->validate(TestConstraintValidator::VALUE_BUILD_VIOLATION, $this->constraint);
     }
 
-    public function testBuildViolationAtPath(): void
+    public function testBuildViolationViaBuilderAtPath(): void
     {
         $this->expectViolationViaBuilder($this->constraint->message, atPath: 'foo', invalidValue: 'bar');
         $this->validator->validate(TestConstraintValidator::VALUE_BUILD_VIOLATION_AT_PATH, $this->constraint);
+    }
+
+    public function testBuildViolationConsecutiveParameters(): void
+    {
+        $this->expectBuildViolation($this->constraint->message)
+            ->expectSetParameterWithConsecutive(['parameter1', 'foo'], ['parameter2', 'bar'])
+            ->expectAddViolation();
+        $this->validator->validate(TestConstraintValidator::VALUE_BUILD_VIOLATION_PARAMETERS, $this->constraint);
+    }
+
+    public function testBuildViolation(): void
+    {
+        $this->expectBuildViolation($this->constraint->message, ['param' => 'eter'])
+            ->expectSetCode('code')
+            ->expectSetPlural(2)
+            ->expectSetCause('cause')
+            ->expectSetTranslationDomain('domain')
+            ->expectSetParameter('set', 'parameter')
+            ->expectSetParameters(['parameter2' => 'two'])
+            ->expectAtPath('foo')
+            ->expectSetInvalidValue('bar')
+            ->expectAddViolation();
+        $this->validator->validate(TestConstraintValidator::VALUE_BUILD_VIOLATION_COMPLETE, $this->constraint);
     }
 }

--- a/tests/Resources/Symfony/Constraint/TestConstraintValidator.php
+++ b/tests/Resources/Symfony/Constraint/TestConstraintValidator.php
@@ -10,9 +10,11 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 class TestConstraintValidator extends ConstraintValidator
 {
-    public const VALUE_ADD_VIOLATION           = 'invalidAddViolation';
-    public const VALUE_BUILD_VIOLATION         = 'invalidBuildViolation';
-    public const VALUE_BUILD_VIOLATION_AT_PATH = 'invalidBuildViolationAtPath';
+    public const VALUE_ADD_VIOLATION              = 'invalidAddViolation';
+    public const VALUE_BUILD_VIOLATION            = 'invalidBuildViolation';
+    public const VALUE_BUILD_VIOLATION_AT_PATH    = 'invalidBuildViolationAtPath';
+    public const VALUE_BUILD_VIOLATION_PARAMETERS = 'invalidBuildViolationParameters';
+    public const VALUE_BUILD_VIOLATION_COMPLETE   = 'invalidBuildViolationComplete';
 
     public function validate(mixed $value, Constraint $constraint): void
     {
@@ -25,6 +27,22 @@ class TestConstraintValidator extends ConstraintValidator
             $this->context->buildViolation($constraint->message)->addViolation();
         } elseif ($value === self::VALUE_BUILD_VIOLATION_AT_PATH) {
             $this->context->buildViolation($constraint->message)->atPath('foo')->setInvalidValue('bar')->addViolation();
+        } elseif ($value === self::VALUE_BUILD_VIOLATION_PARAMETERS) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('parameter1', 'foo')
+                ->setParameter('parameter2', 'bar')
+                ->addViolation();
+        } elseif ($value === self::VALUE_BUILD_VIOLATION_COMPLETE) {
+            $this->context->buildViolation($constraint->message, ['param' => 'eter'])
+                ->setCode('code')
+                ->setPlural(2)
+                ->setCause('cause')
+                ->setTranslationDomain('domain')
+                ->setParameter('set', 'parameter')
+                ->setParameters(['parameter2' => 'two'])
+                ->atPath('foo')
+                ->setInvalidValue('bar')
+                ->addViolation();
         }
     }
 }


### PR DESCRIPTION
Add support for fluent constraint builder notation:

Your constraint
``` 
$this->context
    ->buildViolation('message')
    ->atPath('price')
    ->setInvalidValue(5.0)
    ->addViolation();
```

The test:
```
$this->expectBuildViolation('message')
     ->expectAtPath('price')
     ->expectSetInvalidValue(5.0)
     ->expectAddViolation();
```