### PR TITLE
Add getForm method to FormAssertions

### DIFF
--- a/src/Symfony/Helper/FormAssertion.php
+++ b/src/Symfony/Helper/FormAssertion.php
@@ -121,4 +121,9 @@ class FormAssertion
 
         return $this;
     }
+
+    public function getForm(): FormInterface
+    {
+        return $this->form;
+    }
 }


### PR DESCRIPTION
for cases where you need the Form object in your testcase, for example to assert that it's correctly passed to another class