### PR TITLE
Update consecutive return type

### DIFF
--- a/src/Mock/consecutive.php
+++ b/src/Mock/consecutive.php
@@ -19,7 +19,7 @@ if (function_exists('\DR\PHPUnitExtensions\Mock\consecutive') === false) {
      *
      * @note    Full qualified name to appease to phpstorm inspection gods
      *  phpcs:ignore
-     * @return \PHPUnit\Framework\Constraint\Callback<mixed>[]
+     * @return list<\PHPUnit\Framework\Constraint\Callback<mixed>>
      * @example <code>->with(...consecutive([5, 'foo'], [6, 'bar']))</code>
      */
     function consecutive(array $firstInvocationArguments, array $secondInvocationArguments, array ...$expectedArgumentList): array


### PR DESCRIPTION
Fixes issue with phpstan:
` Method PHPUnit\Framework\MockObject\Builder\InvocationMocker::with() invoked with unpacked array with possibly string key, but it's not allowed because of @no-named-arguments.`
