### PR TITLE
Add expectSubmit on FormAssertion

### DIFF
--- a/src/Symfony/Helper/FormAssertion.php
+++ b/src/Symfony/Helper/FormAssertion.php
@@ -36,6 +36,16 @@ class FormAssertion
     }
 
     /**
+     * @param string|array<array-key, mixed>|null $submittedData
+     */
+    public function expectSubmit(string|array|null $submittedData, bool $clearMissing = true): self
+    {
+        $this->form->expects(atLeastOnce())->method('submit')->with($submittedData, $clearMissing)->willReturnSelf();
+
+        return $this;
+    }
+
+    /**
      * @param array<string, int|string|float|null> $keyValueData
      */
     public function getWillReturn(array $keyValueData): self

--- a/tests/Integration/Symfony/Controller/FormWithSubmitControllerTest.php
+++ b/tests/Integration/Symfony/Controller/FormWithSubmitControllerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DR\PHPUnitExtensions\Tests\Integration\Symfony\Controller;
+
+use DR\PHPUnitExtensions\Symfony\AbstractControllerTestCase;
+use DR\PHPUnitExtensions\Symfony\Helper\FormAssertion;
+use DR\PHPUnitExtensions\Tests\Resources\Symfony\Controller\FormWithSubmitController;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @extends AbstractControllerTestCase<FormWithSubmitController>
+ */
+#[CoversClass(AbstractControllerTestCase::class)]
+#[CoversClass(FormAssertion::class)]
+class FormWithSubmitControllerTest extends AbstractControllerTestCase
+{
+    public function testInvoke(): void
+    {
+        $request = new Request(['foo' => 'bar']);
+        $this->expectCreateForm(FormType::class)
+            ->expectSubmit(['foo' => 'bar'], false);
+
+        ($this->controller)($request);
+    }
+
+    public function getController(): FormWithSubmitController
+    {
+        return new FormWithSubmitController();
+    }
+}

--- a/tests/Resources/Symfony/Controller/FormWithSubmitController.php
+++ b/tests/Resources/Symfony/Controller/FormWithSubmitController.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DR\PHPUnitExtensions\Tests\Resources\Symfony\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\HttpFoundation\Request;
+
+class FormWithSubmitController extends AbstractController
+{
+    public function __invoke(Request $request): void
+    {
+        $form = $this->createForm(FormType::class);
+        $form->submit($request->query->all(), false);
+    }
+}


### PR DESCRIPTION
Adds support for `expectSubmit` which can be used after createForm

```php
$form = $this->createForm(MyFormType::class);

$form->submit($request->query->all());
if ($form->isSubmitted() === false || $form->isValid() === false) {
   throw new BadRequestException();
}
```

Can now be asserted with:
```php
$this->expectCreateForm(MyFormType::class)
    ->expectSubmit(['foo' => 'bar'])
    ->isSubmittedWillReturn(true)
    ->isValidWillReturn(true);
```