### PR TITLE
Add output url to image diff renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The `PdfTestTrait` provides methods to compare a `TCPDF` object against an image
 **For both ImageTestTrait and PdfTestTrait:**
 
 The environment variable `PHPUNIT_EXTENSIONS_IMAGE_DIFF_OUTPUT_PATH` can be set to a directory where a `diff.html` will be generated which will
-show the differences. Optionally, the environment variable `PHPUNIT_EXTENSIONS_IMAGE_DIFF_OUTPUT_URL` can be set to to inform the user where
+show the differences. Optionally, the environment variable `PHPUNIT_EXTENSIONS_IMAGE_DIFF_OUTPUT_URL` can be set to inform the user where
 to find the outputted `diff.html` file. This is useful when running tests in a CI environment.
 
 ## About us

--- a/README.md
+++ b/README.md
@@ -140,8 +140,11 @@ The `PdfTestTrait` provides methods to compare a `TCPDF` object against an image
 - `self::assertSamePdf(string|SplFileInfo|resource|TCPDF, TCPDF)`
 - `self::assertNotSamePdf(string|SplFileInfo|resource|TCPDF, TCPDF)`.
 
+**For both ImageTestTrait and PdfTestTrait:**
+
 The environment variable `PHPUNIT_EXTENSIONS_IMAGE_DIFF_OUTPUT_PATH` can be set to a directory where a `diff.html` will be generated which will
-show the differences.
+show the differences. Optionally, the environment variable `PHPUNIT_EXTENSIONS_IMAGE_DIFF_OUTPUT_URL` can be set to to inform the user where
+to find the outputted `diff.html` file. This is useful when running tests in a CI environment.
 
 ## About us
 

--- a/src/Renderer/ImageDiffRenderer.php
+++ b/src/Renderer/ImageDiffRenderer.php
@@ -9,16 +9,22 @@ use ImagickException;
 
 /**
  * Renders the results IsSameImageConstraint difference to local html file. Can be enabled by setting the `PHPUNIT_EXTENSIONS_IMAGE_DIFF_OUTPUT_PATH`
+ * Optionally an output url can be set which will be used to notify the user where to find the rendered diff.
  */
 class ImageDiffRenderer implements ImageDiffRendererInterface
 {
     private readonly ?string $outputPath;
+    private readonly ?string $outputUrl;
 
-    public function __construct(?string $outputPath = null)
+    public function __construct(?string $outputPath = null, ?string $outputUrl = null)
     {
         $outputPath ??= $_SERVER['PHPUNIT_EXTENSIONS_IMAGE_DIFF_OUTPUT_PATH'] ?? null;
         assert(is_string($outputPath) || $outputPath === null, 'PHPUNIT_EXTENSIONS_IMAGE_DIFF_OUTPUT_PATH must be a string or null');
         $this->outputPath = $outputPath;
+
+        $outputUrl ??= $_SERVER['PHPUNIT_EXTENSIONS_IMAGE_DIFF_OUTPUT_URL'] ?? null;
+        assert(is_string($outputUrl) || $outputUrl === null, 'PHPUNIT_EXTENSIONS_IMAGE_DIFF_OUTPUT_URL must be a string or null');
+        $this->outputUrl = $outputUrl;
     }
 
     /**
@@ -48,7 +54,7 @@ class ImageDiffRenderer implements ImageDiffRendererInterface
         $html     = str_replace(array_keys($replaces), array_values($replaces), $this->createHtml());
         file_put_contents($this->outputPath . DIRECTORY_SEPARATOR . 'diff.html', $html);
 
-        return 'View the differences at ' . $this->outputPath . '/diff.html';
+        return 'View the differences at ' . ($this->outputUrl === null ? $this->outputPath : $this->outputUrl) . '/diff.html';
     }
 
     private function createHtml(): string

--- a/src/Renderer/ImageDiffRenderer.php
+++ b/src/Renderer/ImageDiffRenderer.php
@@ -54,7 +54,7 @@ class ImageDiffRenderer implements ImageDiffRendererInterface
         $html     = str_replace(array_keys($replaces), array_values($replaces), $this->createHtml());
         file_put_contents($this->outputPath . DIRECTORY_SEPARATOR . 'diff.html', $html);
 
-        return 'View the differences at ' . ($this->outputUrl === null ? realpath($this->outputPath) : $this->outputUrl) . '/diff.html';
+        return 'View the differences at ' . ($this->outputUrl === null ? $this->outputPath : $this->outputUrl) . '/diff.html';
     }
 
     private function createHtml(): string

--- a/src/Renderer/ImageDiffRenderer.php
+++ b/src/Renderer/ImageDiffRenderer.php
@@ -20,11 +20,11 @@ class ImageDiffRenderer implements ImageDiffRendererInterface
     {
         $outputPath ??= $_SERVER['PHPUNIT_EXTENSIONS_IMAGE_DIFF_OUTPUT_PATH'] ?? null;
         assert(is_string($outputPath) || $outputPath === null, 'PHPUNIT_EXTENSIONS_IMAGE_DIFF_OUTPUT_PATH must be a string or null');
-        $this->outputPath = $outputPath;
+        $this->outputPath = $outputPath !== null ? rtrim($outputPath, '/\\') : null;
 
         $outputUrl ??= $_SERVER['PHPUNIT_EXTENSIONS_IMAGE_DIFF_OUTPUT_URL'] ?? null;
         assert(is_string($outputUrl) || $outputUrl === null, 'PHPUNIT_EXTENSIONS_IMAGE_DIFF_OUTPUT_URL must be a string or null');
-        $this->outputUrl = $outputUrl;
+        $this->outputUrl = $outputUrl !== null ? rtrim($outputUrl, '/') : null;
     }
 
     /**

--- a/src/Renderer/ImageDiffRenderer.php
+++ b/src/Renderer/ImageDiffRenderer.php
@@ -54,7 +54,7 @@ class ImageDiffRenderer implements ImageDiffRendererInterface
         $html     = str_replace(array_keys($replaces), array_values($replaces), $this->createHtml());
         file_put_contents($this->outputPath . DIRECTORY_SEPARATOR . 'diff.html', $html);
 
-        return 'View the differences at ' . ($this->outputUrl === null ? $this->outputPath : $this->outputUrl) . '/diff.html';
+        return 'View the differences at ' . ($this->outputUrl === null ? realpath($this->outputPath) : $this->outputUrl) . '/diff.html';
     }
 
     private function createHtml(): string

--- a/tests/Unit/Renderer/ImageDiffRendererTest.php
+++ b/tests/Unit/Renderer/ImageDiffRendererTest.php
@@ -59,4 +59,22 @@ class ImageDiffRendererTest extends TestCase
         static::assertNull($result);
         static::assertFileDoesNotExist($this->path . '/pdf/diff.html');
     }
+
+    public function testRenderShouldWithOutputUrl(): void
+    {
+        $diff = $this->createMock(Imagick::class);
+        $diff->expects(static::once())->method('setImageFormat')->with('png');
+        $diff->expects(static::once())->method('getImageBlob')->willReturn('diff');
+
+        $expected = $this->createMock(Imagick::class);
+        $expected->expects(static::once())->method('setImageFormat')->with('png');
+        $expected->expects(static::once())->method('getImageBlob')->willReturn('expected');
+
+        $actual = $this->createMock(Imagick::class);
+        $actual->expects(static::once())->method('setImageFormat')->with('png');
+        $actual->expects(static::once())->method('getImageBlob')->willReturn('actual');
+
+        $result = (new ImageDiffRenderer($this->path . '/pdf', 'https://example.com/'))->render($diff, $expected, $actual);
+        static::assertSame('View the differences at https://example.com/diff.html', $result);
+    }
 }

--- a/tests/Unit/Renderer/ImageDiffRendererTest.php
+++ b/tests/Unit/Renderer/ImageDiffRendererTest.php
@@ -60,7 +60,7 @@ class ImageDiffRendererTest extends TestCase
         static::assertFileDoesNotExist($this->path . '/pdf/diff.html');
     }
 
-    public function testRenderShouldWithOutputUrl(): void
+    public function testRenderShouldShowOutputUrl(): void
     {
         $diff = $this->createMock(Imagick::class);
         $diff->expects(static::once())->method('setImageFormat')->with('png');


### PR DESCRIPTION
Adds `PHPUNIT_EXTENSIONS_IMAGE_DIFF_OUTPUT_URL` to the `ImageDiffRenderer` to optionally set a url where the rendered diff will be available.