### PR TITLE
Add expectIsGranted method

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,12 @@ class MyControllerTest extends AbstractControllerTestCase
 
 **Methods**
 - `expectGetUser`
+- `expectIsGranted`
 - `expectDenyAccessUnlessGranted`
 - `expectCreateForm`
 - `expectAddFlash`
 - `expectGenerateUrl`
+- `expectGenerateUrlWithConsecutive`
 - `expectRedirectToRoute`
 - `expectForward`
 - `expectRender`

--- a/src/Symfony/AbstractControllerTestCase.php
+++ b/src/Symfony/AbstractControllerTestCase.php
@@ -55,6 +55,14 @@ abstract class AbstractControllerTestCase extends TestCase
         $this->container->set('security.token_storage', $storage);
     }
 
+    public function expectIsGranted(string $attribute, mixed $subject = null, bool $granted = true): void
+    {
+        $checker = $this->createMock(AuthorizationCheckerInterface::class);
+        $checker->expects(self::atLeastOnce())->method('isGranted')->with($attribute, $subject)->willReturn($granted);
+
+        $this->container->set('security.authorization_checker', $checker);
+    }
+
     /**
      * Alias of expectIsGranted
      * Symfony has the method `denyAccessUnlessGranted` in the AbstractController class to call isGranted
@@ -64,14 +72,6 @@ abstract class AbstractControllerTestCase extends TestCase
     public function expectDenyAccessUnlessGranted(string $attribute, mixed $subject = null, bool $granted = true): void
     {
         $this->expectIsGranted($attribute, $subject, $granted);
-    }
-
-    public function expectIsGranted(string $attribute, mixed $subject = null, bool $granted = true): void
-    {
-        $checker = $this->createMock(AuthorizationCheckerInterface::class);
-        $checker->expects(self::atLeastOnce())->method('isGranted')->with($attribute, $subject)->willReturn($granted);
-
-        $this->container->set('security.authorization_checker', $checker);
     }
 
     /**

--- a/src/Symfony/AbstractControllerTestCase.php
+++ b/src/Symfony/AbstractControllerTestCase.php
@@ -55,7 +55,18 @@ abstract class AbstractControllerTestCase extends TestCase
         $this->container->set('security.token_storage', $storage);
     }
 
+    /**
+     * Alias of expectIsGranted
+     * Symfony has the method `denyAccessUnlessGranted` in the AbstractController class to call isGranted
+     * and throw an exception if the access is denied.
+     * @see expectIsGranted()
+     */
     public function expectDenyAccessUnlessGranted(string $attribute, mixed $subject = null, bool $granted = true): void
+    {
+        $this->expectIsGranted($attribute, $subject, $granted);
+    }
+
+    public function expectIsGranted(string $attribute, mixed $subject = null, bool $granted = true): void
     {
         $checker = $this->createMock(AuthorizationCheckerInterface::class);
         $checker->expects(self::atLeastOnce())->method('isGranted')->with($attribute, $subject)->willReturn($granted);

--- a/tests/Integration/Symfony/Controller/SecurityIsGrantedControllerTest.php
+++ b/tests/Integration/Symfony/Controller/SecurityIsGrantedControllerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DR\PHPUnitExtensions\Tests\Integration\Symfony\Controller;
+
+use DR\PHPUnitExtensions\Symfony\AbstractControllerTestCase;
+use DR\PHPUnitExtensions\Tests\Resources\Symfony\Controller\SecurityIsGrantedController;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * @extends AbstractControllerTestCase<SecurityIsGrantedController>
+ */
+#[CoversClass(AbstractControllerTestCase::class)]
+class SecurityIsGrantedControllerTest extends AbstractControllerTestCase
+{
+    public function getController(): SecurityIsGrantedController
+    {
+        return new SecurityIsGrantedController();
+    }
+
+    public function testInvoke(): void
+    {
+        $this->expectIsGranted("ROLE_SECURITY");
+        static::assertSame("Granted", ($this->controller)()->getContent());
+    }
+
+    public function testInvokeNoAccess(): void
+    {
+        $this->expectIsGranted("ROLE_SECURITY", null, false);
+        static::assertSame("Not granted", ($this->controller)()->getContent());
+    }
+}

--- a/tests/Resources/Symfony/Controller/SecurityIsGrantedController.php
+++ b/tests/Resources/Symfony/Controller/SecurityIsGrantedController.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DR\PHPUnitExtensions\Tests\Resources\Symfony\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+
+class SecurityIsGrantedController extends AbstractController
+{
+    public function __invoke(): Response
+    {
+        if ($this->isGranted("ROLE_SECURITY") === false) {
+            return new Response("not granted");
+        }
+
+        return new Response("Granted");
+    }
+}


### PR DESCRIPTION
Symfony has both isGranted and denyAccessUnlessGranted, where denyAccessUnlessGranted uses isGranted internally

When testing a controller that uses isGranted instead of denyAccessUnlessGranted, it makes more sense to also use expectIsGranted