### PR TITLE
Fix expects abstract constraint validator test case

### DIFF
--- a/src/Symfony/AbstractConstraintValidatorTestCase.php
+++ b/src/Symfony/AbstractConstraintValidatorTestCase.php
@@ -154,8 +154,6 @@ abstract class AbstractConstraintValidatorTestCase extends TestCase
     {
         $this->executionContext->expects(static::once())->method('buildViolation')->with($message, $parameters)->willReturn($this->violationBuilder);
 
-        $this->violationBuilder->expects(static::never())->method(self::anything());
-
         return new ConstraintViolationBuilderAssertion($this->violationBuilder);
     }
 }

--- a/src/Symfony/AbstractConstraintValidatorTestCase.php
+++ b/src/Symfony/AbstractConstraintValidatorTestCase.php
@@ -80,12 +80,17 @@ abstract class AbstractConstraintValidatorTestCase extends TestCase
     {
         $this->expectException(UnexpectedTypeException::class);
         $this->validator->validate($value, $this->createMock(Constraint::class));
+
+        $this->executionContext->expects($this->never())->method(self::anything());
+        $this->violationBuilder->expects($this->never())->method(self::anything());
     }
 
     protected function expectNoViolations(): void
     {
-        $this->executionContext->expects(static::never())->method('buildViolation');
-        $this->executionContext->expects(static::never())->method('addViolation');
+        $this->executionContext->expects($this->never())->method('buildViolation');
+        $this->executionContext->expects($this->never())->method('addViolation');
+
+        $this->violationBuilder->expects($this->never())->method(self::anything());
     }
 
     /**
@@ -96,7 +101,9 @@ abstract class AbstractConstraintValidatorTestCase extends TestCase
      */
     protected function expectViolation(string $message, array $parameters = []): void
     {
-        $this->executionContext->expects(static::once())->method('addViolation')->with($message, $parameters);
+        $this->executionContext->expects($this->once())->method('addViolation')->with($message, $parameters);
+
+        $this->violationBuilder->expects($this->never())->method(self::anything());
     }
 
     /**
@@ -113,14 +120,14 @@ abstract class AbstractConstraintValidatorTestCase extends TestCase
         ?string $atPath = null,
         mixed $invalidValue = self::IGNORE_INVALID_VALUE
     ): void {
-        $this->executionContext->expects(static::once())->method('buildViolation')->with($message, $parameters)->willReturn($this->violationBuilder);
+        $this->executionContext->expects($this->once())->method('buildViolation')->with($message, $parameters)->willReturn($this->violationBuilder);
         if ($atPath !== null) {
-            $this->violationBuilder->expects(static::once())->method('atPath')->with($atPath)->willReturnSelf();
+            $this->violationBuilder->expects($this->once())->method('atPath')->with($atPath)->willReturnSelf();
         }
         if ($invalidValue !== self::IGNORE_INVALID_VALUE) {
-            $this->violationBuilder->expects(static::once())->method('setInvalidValue')->with($invalidValue)->willReturnSelf();
+            $this->violationBuilder->expects($this->once())->method('setInvalidValue')->with($invalidValue)->willReturnSelf();
         }
-        $this->violationBuilder->expects(static::once())->method('addViolation');
+        $this->violationBuilder->expects($this->once())->method('addViolation');
     }
 
     /**
@@ -145,7 +152,9 @@ abstract class AbstractConstraintValidatorTestCase extends TestCase
      */
     protected function expectBuildViolation(string $message, array $parameters = []): ConstraintViolationBuilderAssertion
     {
-        $this->executionContext->expects(static::once())->method('buildViolation')->with($message, $parameters)->willReturn($this->violationBuilder);
+        $this->executionContext->expects($this->once())->method('buildViolation')->with($message, $parameters)->willReturn($this->violationBuilder);
+
+        $this->violationBuilder->expects($this->never())->method(self::anything());
 
         return new ConstraintViolationBuilderAssertion($this->violationBuilder);
     }

--- a/src/Symfony/AbstractConstraintValidatorTestCase.php
+++ b/src/Symfony/AbstractConstraintValidatorTestCase.php
@@ -78,11 +78,12 @@ abstract class AbstractConstraintValidatorTestCase extends TestCase
      */
     protected function assertHandlesIncorrectConstraintType(mixed $value = null): void
     {
+        $this->executionContext->expects(static::never())->method($this->anything());
+        $this->violationBuilder->expects(static::never())->method($this->anything());
+
         $this->expectException(UnexpectedTypeException::class);
         $this->validator->validate($value, $this->createMock(Constraint::class));
 
-        $this->executionContext->expects(static::never())->method(self::anything());
-        $this->violationBuilder->expects(static::never())->method(self::anything());
     }
 
     protected function expectNoViolations(): void
@@ -90,7 +91,7 @@ abstract class AbstractConstraintValidatorTestCase extends TestCase
         $this->executionContext->expects(static::never())->method('buildViolation');
         $this->executionContext->expects(static::never())->method('addViolation');
 
-        $this->violationBuilder->expects(static::never())->method(self::anything());
+        $this->violationBuilder->expects(static::never())->method($this->anything());
     }
 
     /**
@@ -103,7 +104,7 @@ abstract class AbstractConstraintValidatorTestCase extends TestCase
     {
         $this->executionContext->expects(static::once())->method('addViolation')->with($message, $parameters);
 
-        $this->violationBuilder->expects(static::never())->method(self::anything());
+        $this->violationBuilder->expects(static::never())->method($this->anything());
     }
 
     /**

--- a/src/Symfony/AbstractConstraintValidatorTestCase.php
+++ b/src/Symfony/AbstractConstraintValidatorTestCase.php
@@ -78,8 +78,8 @@ abstract class AbstractConstraintValidatorTestCase extends TestCase
      */
     protected function assertHandlesIncorrectConstraintType(mixed $value = null): void
     {
-        $this->executionContext->expects(static::never())->method($this->anything());
-        $this->violationBuilder->expects(static::never())->method($this->anything());
+        $this->executionContext->expects(self::never())->method(self::anything());
+        $this->violationBuilder->expects(self::never())->method(self::anything());
 
         $this->expectException(UnexpectedTypeException::class);
         $this->validator->validate($value, $this->createMock(Constraint::class));
@@ -88,10 +88,10 @@ abstract class AbstractConstraintValidatorTestCase extends TestCase
 
     protected function expectNoViolations(): void
     {
-        $this->executionContext->expects(static::never())->method('buildViolation');
-        $this->executionContext->expects(static::never())->method('addViolation');
+        $this->executionContext->expects(self::never())->method('buildViolation');
+        $this->executionContext->expects(self::never())->method('addViolation');
 
-        $this->violationBuilder->expects(static::never())->method($this->anything());
+        $this->violationBuilder->expects(self::never())->method(self::anything());
     }
 
     /**
@@ -102,9 +102,9 @@ abstract class AbstractConstraintValidatorTestCase extends TestCase
      */
     protected function expectViolation(string $message, array $parameters = []): void
     {
-        $this->executionContext->expects(static::once())->method('addViolation')->with($message, $parameters);
+        $this->executionContext->expects(self::once())->method('addViolation')->with($message, $parameters);
 
-        $this->violationBuilder->expects(static::never())->method($this->anything());
+        $this->violationBuilder->expects(self::never())->method(self::anything());
     }
 
     /**
@@ -121,14 +121,14 @@ abstract class AbstractConstraintValidatorTestCase extends TestCase
         ?string $atPath = null,
         mixed $invalidValue = self::IGNORE_INVALID_VALUE
     ): void {
-        $this->executionContext->expects(static::once())->method('buildViolation')->with($message, $parameters)->willReturn($this->violationBuilder);
+        $this->executionContext->expects(self::once())->method('buildViolation')->with($message, $parameters)->willReturn($this->violationBuilder);
         if ($atPath !== null) {
-            $this->violationBuilder->expects(static::once())->method('atPath')->with($atPath)->willReturnSelf();
+            $this->violationBuilder->expects(self::once())->method('atPath')->with($atPath)->willReturnSelf();
         }
         if ($invalidValue !== self::IGNORE_INVALID_VALUE) {
-            $this->violationBuilder->expects(static::once())->method('setInvalidValue')->with($invalidValue)->willReturnSelf();
+            $this->violationBuilder->expects(self::once())->method('setInvalidValue')->with($invalidValue)->willReturnSelf();
         }
-        $this->violationBuilder->expects(static::once())->method('addViolation');
+        $this->violationBuilder->expects(self::once())->method('addViolation');
     }
 
     /**
@@ -153,7 +153,7 @@ abstract class AbstractConstraintValidatorTestCase extends TestCase
      */
     protected function expectBuildViolation(string $message, array $parameters = []): ConstraintViolationBuilderAssertion
     {
-        $this->executionContext->expects(static::once())->method('buildViolation')->with($message, $parameters)->willReturn($this->violationBuilder);
+        $this->executionContext->expects(self::once())->method('buildViolation')->with($message, $parameters)->willReturn($this->violationBuilder);
 
         return new ConstraintViolationBuilderAssertion($this->violationBuilder);
     }

--- a/src/Symfony/AbstractConstraintValidatorTestCase.php
+++ b/src/Symfony/AbstractConstraintValidatorTestCase.php
@@ -81,16 +81,16 @@ abstract class AbstractConstraintValidatorTestCase extends TestCase
         $this->expectException(UnexpectedTypeException::class);
         $this->validator->validate($value, $this->createMock(Constraint::class));
 
-        $this->executionContext->expects($this->never())->method(self::anything());
-        $this->violationBuilder->expects($this->never())->method(self::anything());
+        $this->executionContext->expects(static::never())->method(self::anything());
+        $this->violationBuilder->expects(static::never())->method(self::anything());
     }
 
     protected function expectNoViolations(): void
     {
-        $this->executionContext->expects($this->never())->method('buildViolation');
-        $this->executionContext->expects($this->never())->method('addViolation');
+        $this->executionContext->expects(static::never())->method('buildViolation');
+        $this->executionContext->expects(static::never())->method('addViolation');
 
-        $this->violationBuilder->expects($this->never())->method(self::anything());
+        $this->violationBuilder->expects(static::never())->method(self::anything());
     }
 
     /**
@@ -101,9 +101,9 @@ abstract class AbstractConstraintValidatorTestCase extends TestCase
      */
     protected function expectViolation(string $message, array $parameters = []): void
     {
-        $this->executionContext->expects($this->once())->method('addViolation')->with($message, $parameters);
+        $this->executionContext->expects(static::once())->method('addViolation')->with($message, $parameters);
 
-        $this->violationBuilder->expects($this->never())->method(self::anything());
+        $this->violationBuilder->expects(static::never())->method(self::anything());
     }
 
     /**
@@ -120,14 +120,14 @@ abstract class AbstractConstraintValidatorTestCase extends TestCase
         ?string $atPath = null,
         mixed $invalidValue = self::IGNORE_INVALID_VALUE
     ): void {
-        $this->executionContext->expects($this->once())->method('buildViolation')->with($message, $parameters)->willReturn($this->violationBuilder);
+        $this->executionContext->expects(static::once())->method('buildViolation')->with($message, $parameters)->willReturn($this->violationBuilder);
         if ($atPath !== null) {
-            $this->violationBuilder->expects($this->once())->method('atPath')->with($atPath)->willReturnSelf();
+            $this->violationBuilder->expects(static::once())->method('atPath')->with($atPath)->willReturnSelf();
         }
         if ($invalidValue !== self::IGNORE_INVALID_VALUE) {
-            $this->violationBuilder->expects($this->once())->method('setInvalidValue')->with($invalidValue)->willReturnSelf();
+            $this->violationBuilder->expects(static::once())->method('setInvalidValue')->with($invalidValue)->willReturnSelf();
         }
-        $this->violationBuilder->expects($this->once())->method('addViolation');
+        $this->violationBuilder->expects(static::once())->method('addViolation');
     }
 
     /**
@@ -152,9 +152,9 @@ abstract class AbstractConstraintValidatorTestCase extends TestCase
      */
     protected function expectBuildViolation(string $message, array $parameters = []): ConstraintViolationBuilderAssertion
     {
-        $this->executionContext->expects($this->once())->method('buildViolation')->with($message, $parameters)->willReturn($this->violationBuilder);
+        $this->executionContext->expects(static::once())->method('buildViolation')->with($message, $parameters)->willReturn($this->violationBuilder);
 
-        $this->violationBuilder->expects($this->never())->method(self::anything());
+        $this->violationBuilder->expects(static::never())->method(self::anything());
 
         return new ConstraintViolationBuilderAssertion($this->violationBuilder);
     }

--- a/src/Symfony/AbstractConstraintValidatorTestCase.php
+++ b/src/Symfony/AbstractConstraintValidatorTestCase.php
@@ -83,7 +83,6 @@ abstract class AbstractConstraintValidatorTestCase extends TestCase
 
         $this->expectException(UnexpectedTypeException::class);
         $this->validator->validate($value, $this->createMock(Constraint::class));
-
     }
 
     protected function expectNoViolations(): void

--- a/src/Symfony/AbstractConstraintValidatorTestCase.php
+++ b/src/Symfony/AbstractConstraintValidatorTestCase.php
@@ -82,7 +82,7 @@ abstract class AbstractConstraintValidatorTestCase extends TestCase
         $this->violationBuilder->expects(self::never())->method(self::anything());
 
         $this->expectException(UnexpectedTypeException::class);
-        $this->validator->validate($value, $this->createMock(Constraint::class));
+        $this->validator->validate($value, static::createStub(Constraint::class));
     }
 
     protected function expectNoViolations(): void

--- a/src/Symfony/AbstractConstraintValidatorTestCase.php
+++ b/src/Symfony/AbstractConstraintValidatorTestCase.php
@@ -78,14 +78,19 @@ abstract class AbstractConstraintValidatorTestCase extends TestCase
      */
     protected function assertHandlesIncorrectConstraintType(mixed $value = null): void
     {
+        $this->executionContext->expects(self::never())->method(self::anything());
+        $this->violationBuilder->expects(self::never())->method(self::anything());
+
         $this->expectException(UnexpectedTypeException::class);
         $this->validator->validate($value, $this->createMock(Constraint::class));
     }
 
     protected function expectNoViolations(): void
     {
-        $this->executionContext->expects(static::never())->method('buildViolation');
-        $this->executionContext->expects(static::never())->method('addViolation');
+        $this->executionContext->expects(self::never())->method('buildViolation');
+        $this->executionContext->expects(self::never())->method('addViolation');
+
+        $this->violationBuilder->expects(self::never())->method(self::anything());
     }
 
     /**
@@ -96,7 +101,9 @@ abstract class AbstractConstraintValidatorTestCase extends TestCase
      */
     protected function expectViolation(string $message, array $parameters = []): void
     {
-        $this->executionContext->expects(static::once())->method('addViolation')->with($message, $parameters);
+        $this->executionContext->expects(self::once())->method('addViolation')->with($message, $parameters);
+
+        $this->violationBuilder->expects(self::never())->method(self::anything());
     }
 
     /**
@@ -113,14 +120,14 @@ abstract class AbstractConstraintValidatorTestCase extends TestCase
         ?string $atPath = null,
         mixed $invalidValue = self::IGNORE_INVALID_VALUE
     ): void {
-        $this->executionContext->expects(static::once())->method('buildViolation')->with($message, $parameters)->willReturn($this->violationBuilder);
+        $this->executionContext->expects(self::once())->method('buildViolation')->with($message, $parameters)->willReturn($this->violationBuilder);
         if ($atPath !== null) {
-            $this->violationBuilder->expects(static::once())->method('atPath')->with($atPath)->willReturnSelf();
+            $this->violationBuilder->expects(self::once())->method('atPath')->with($atPath)->willReturnSelf();
         }
         if ($invalidValue !== self::IGNORE_INVALID_VALUE) {
-            $this->violationBuilder->expects(static::once())->method('setInvalidValue')->with($invalidValue)->willReturnSelf();
+            $this->violationBuilder->expects(self::once())->method('setInvalidValue')->with($invalidValue)->willReturnSelf();
         }
-        $this->violationBuilder->expects(static::once())->method('addViolation');
+        $this->violationBuilder->expects(self::once())->method('addViolation');
     }
 
     /**
@@ -145,7 +152,7 @@ abstract class AbstractConstraintValidatorTestCase extends TestCase
      */
     protected function expectBuildViolation(string $message, array $parameters = []): ConstraintViolationBuilderAssertion
     {
-        $this->executionContext->expects(static::once())->method('buildViolation')->with($message, $parameters)->willReturn($this->violationBuilder);
+        $this->executionContext->expects(self::once())->method('buildViolation')->with($message, $parameters)->willReturn($this->violationBuilder);
 
         return new ConstraintViolationBuilderAssertion($this->violationBuilder);
     }


### PR DESCRIPTION
Update AbstractConstraintValidatorTestCase::assertHandlesIncorrectConstraintType() to create a Stub instead of a mock